### PR TITLE
git*: Add bash version check

### DIFF
--- a/bin/git-autorebase
+++ b/bin/git-autorebase
@@ -12,11 +12,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# check bash version compatiblity requires 4.2 or better
+shopt -u compat41 2>/dev/null || {
+  echo -n "\nBash Version 4.2 or higher is required!\n";
+  exit 127;
+}
+
 # -----------------------------------------------------------------------------
 # Globals
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare -r VERSION=0.3.0
+declare -r VERSION=0.3.1
 declare -r AUTHOR="Urs Roesch <github@bun.ch>"
 declare -r LICENSE="GLPv2"
 declare -r DIVIDER=$(printf "%0.1s" -{0..80})

--- a/bin/git-fpc
+++ b/bin/git-fpc
@@ -12,6 +12,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# check bash version compatiblity requires 4.2 or better
+shopt -u compat41 2>/dev/null || {
+  echo -n "\nBash Version 4.2 or higher is required!\n";
+  exit 127;
+}
+
 # -----------------------------------------------------------------------------
 # Globals
 # -----------------------------------------------------------------------------

--- a/bin/git-opush
+++ b/bin/git-opush
@@ -11,11 +11,18 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# check bash version compatiblity requires 4.2 or better
+shopt -u compat41 2>/dev/null || {
+  echo -n "\nBash Version 4.2 or higher is required!\n";
+  exit 127;
+}
+
+
 # -----------------------------------------------------------------------------
 # Globals
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare -r VERSION=0.3.0
+declare -r VERSION=0.3.1
 declare -r AUTHOR="Urs Roesch <github@bun.ch>"
 declare -r LICENSE="GPLv2"
 declare -g FORCE=""

--- a/bin/git-walktree
+++ b/bin/git-walktree
@@ -16,11 +16,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# check bash version compatiblity requires 4.2 or better
+shopt -u compat41 2>/dev/null || {
+  echo -n "\nBash Version 4.2 or higher is required!\n";
+  exit 127;
+}
+
 # -----------------------------------------------------------------------------
 # Globals
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare -r VERSION=0.1.1
+declare -r VERSION=0.1.2
 declare -r AUTHOR="Urs Roesch <github@bun.ch>"
 declare -r LICENSE="GPLv2"
 declare -g COMMIT=${1:-HEAD}


### PR DESCRIPTION
Summary:
  * Using `declare -g` requires Bash
    version 4.2 or higher.