### PR TITLE
Bugfix git fpc branch name required

### DIFF
--- a/bin/git-fpc
+++ b/bin/git-fpc
@@ -22,7 +22,7 @@ shopt -u compat41 2>/dev/null || {
 # Globals
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare -r VERSION="0.6.0"
+declare -r VERSION="0.6.1"
 declare -r AUTHOR="Urs Roesch <github@bun.ch>"
 declare -r LICENSE="GPLv2"
 declare -g BASE=""
@@ -155,6 +155,7 @@ function delete_branches() {
   local -a deleted_branches=( $(fetch_prune) )
   local -a local_branches=( $(git branch | grep -wv ${BASE}) )
   for branch in "${deleted_branches[@]:-}"; do
+    [[ -z ${branch} ]] && continue
     if [[ ${local_branches[@]:-} =~ ${branch} ]]; then
       git branch -d ${branch}
     fi

--- a/tests/includes.bash
+++ b/tests/includes.bash
@@ -5,7 +5,7 @@
 # -----------------------------------------------------------------------------
 export PATH=${BATS_TEST_DIRNAME}/../bin:${PATH}
 export GIT_AUTOREBASE_VERSION="v0.7.0"
-export GIT_FPC_VERSION="v0.6.0"
+export GIT_FPC_VERSION="v0.6.1"
 export GIT_OPUSH_VERSION="v0.6.0"
 export GIT_WALKTREE_VERSION="v0.1.2"
 export STRIP_TRAILING_WHITESPACE_VERSION="v0.6.0"


### PR DESCRIPTION
Summary:
  * Prevent `fatal: branch name required`
    message when no branch needs to be
    deleted.

Close #26