### PR TITLE
Bugfix: Correct script name in version output

### DIFF
--- a/bin/git-autorebase
+++ b/bin/git-autorebase
@@ -22,7 +22,7 @@ shopt -u compat41 2>/dev/null || {
 # Globals
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare -r VERSION=0.7.0
+declare -r VERSION=0.7.1
 declare -r AUTHOR="Urs Roesch <github@bun.ch>"
 declare -r LICENSE="GLPv2"
 declare -r DIVIDER=$(printf "%0.1s" -{0..80})
@@ -40,7 +40,7 @@ function usage() {
   cat <<USAGE
 
   Usage:
-    ${SCRIPT//-/ } [options]
+    ${SCRIPT/-/ } [options]
 
   Opttions:
     -h | --help                This message
@@ -79,7 +79,7 @@ function parse_options() {
 
 function version() {
   printf "%s v%s\nCopyright (c) %s\nLicense - %s\n" \
-    "${SCRIPT}" "${VERSION}" "${AUTHOR}" "${LICENSE}"
+    "${SCRIPT/-/ }" "${VERSION}" "${AUTHOR}" "${LICENSE}"
   exit 0
 }
 

--- a/bin/git-fpc
+++ b/bin/git-fpc
@@ -22,7 +22,7 @@ shopt -u compat41 2>/dev/null || {
 # Globals
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare -r VERSION="0.6.1"
+declare -r VERSION="0.6.2"
 declare -r AUTHOR="Urs Roesch <github@bun.ch>"
 declare -r LICENSE="GPLv2"
 declare -g BASE=""
@@ -37,7 +37,7 @@ function usage() {
   cat <<USAGE
 
   Usage:
-    ${SCRIPT//-/ } [options]
+    ${SCRIPT/-/ } [options]
 
   Opttions:
     -h | --help    This message
@@ -72,7 +72,7 @@ function parse_options() {
 
 function version() {
   printf "%s v%s\nCopyright (c) %s\nLicense - %s\n" \
-    "${SCRIPT}" "${VERSION}" "${AUTHOR}" "${LICENSE}"
+    "${SCRIPT/-/ }" "${VERSION}" "${AUTHOR}" "${LICENSE}"
   exit 0
 }
 

--- a/bin/git-opush
+++ b/bin/git-opush
@@ -21,7 +21,7 @@ shopt -u compat41 2>/dev/null || {
 # Globals
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare -r VERSION=0.6.0
+declare -r VERSION=0.6.1
 declare -r AUTHOR="Urs Roesch <github@bun.ch>"
 declare -r LICENSE="GPLv2"
 declare -g FORCE=""
@@ -37,7 +37,7 @@ function usage() {
   cat <<USAGE
 
   Usage:
-    ${SCRIPT//-/ } [options]
+    ${SCRIPT/-/ } [options]
 
   Opttions:
     -h | --help    This message
@@ -75,7 +75,7 @@ function parse_options() {
 
 function version() {
   printf "%s v%s\nCopyright (c) %s\nLicense - %s\n" \
-    "${SCRIPT}" "${VERSION}" "${AUTHOR}" "${LICENSE}"
+    "${SCRIPT/-/ }" "${VERSION}" "${AUTHOR}" "${LICENSE}"
   exit 0
 }
 

--- a/bin/git-walktree
+++ b/bin/git-walktree
@@ -26,7 +26,7 @@ shopt -u compat41 2>/dev/null || {
 # Globals
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare -r VERSION=0.1.2
+declare -r VERSION=0.1.3
 declare -r AUTHOR="Urs Roesch <github@bun.ch>"
 declare -r LICENSE="GPLv2"
 declare -g COMMIT=${1:-HEAD}
@@ -70,7 +70,7 @@ parse_options() {
 
 function version() {
   printf "%s v%s\nCopyright (c) %s\nLicense - %s\n" \
-    "${SCRIPT}" "${VERSION}" "${AUTHOR}" "${LICENSE}"
+    "${SCRIPT/-/ }" "${VERSION}" "${AUTHOR}" "${LICENSE}"
   exit 0
 }
 

--- a/tests/includes.bash
+++ b/tests/includes.bash
@@ -4,10 +4,10 @@
 # Globals
 # -----------------------------------------------------------------------------
 export PATH=${BATS_TEST_DIRNAME}/../bin:${PATH}
-export GIT_AUTOREBASE_VERSION="v0.7.0"
-export GIT_FPC_VERSION="v0.6.1"
-export GIT_OPUSH_VERSION="v0.6.0"
-export GIT_WALKTREE_VERSION="v0.1.2"
+export GIT_AUTOREBASE_VERSION="v0.7.1"
+export GIT_FPC_VERSION="v0.6.2"
+export GIT_OPUSH_VERSION="v0.6.1"
+export GIT_WALKTREE_VERSION="v0.1.3"
 export STRIP_TRAILING_WHITESPACE_VERSION="v0.6.0"
 export SHA256SUM_WHITESPACE_FILE="506dcd8e1fdd674bf75c87191145642a440cd4aa11a95fc37c4197f7a4e5118d"
 export SHA256SUM_WALKTREE="3393faccc9e1f6fd999c49e8efa1df5aed19900d3bbf1ca34b17b05ea34519ac"


### PR DESCRIPTION
Summary:
  * Remove the dash between git and the keyword in the version
    output.
  * Bump the minor number.