### PR TITLE
git stale-branches: Fix default operation mode

### DIFF
--- a/.github/workflows/bash-compatibility.yml
+++ b/.github/workflows/bash-compatibility.yml
@@ -40,7 +40,12 @@ jobs:
       shell: bash
       run: |
         function install-dependencies() {
-          apk add git make grep bats
+          apk add \
+            bats \
+            coreutils \
+            git \
+            grep \
+            make
         }
         docker run \
           --tty \

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@
 # -----------------------------------------------------------------------------
 SHELL := bash
 .ONESHELL:
-.SHELLFLAGS := -o errexit -o nounset -o pipefail -c
+.SHELLFLAGS  := -o errexit -o nounset -o pipefail -c
 .DELETE_ON_ERROR:
-.RECIPEPREFIX = >
-MAKEFLAGS += --warn-undefined-variables
-MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS    += --warn-undefined-variables
+MAKEFLAGS    += --no-builtin-rules
+BASH_VERSION += 4.2
 
 # -----------------------------------------------------------------------------
 # Globals
@@ -18,26 +18,48 @@ USER_BIN   := $(HOME)/bin
 # User install
 # -----------------------------------------------------------------------------
 user_install:
-> @echo "Install git-helpers under $(USER_BIN)"
-> mkdir -p $(USER_BIN) || :
-> for script in bin/*; do
->   basename=$${script##*/}
->   install $${script} $(USER_BIN)/$${basename} && 
->     echo "-> Installing $${script} to $(USER_BIN)/$${basename}"
-> done
+	@echo "Install git-helpers under $(USER_BIN)"
+	mkdir -p $(USER_BIN) || :
+	for script in bin/*; do
+		basename=$${script##*/}
+		install $${script} $(USER_BIN)/$${basename} && 
+			echo "-> Installing $${script} to $(USER_BIN)/$${basename}"
+	done
 
 user_uninstall:
-> @echo "Uninstall git-helpers from $(USER_BIN)"
-> for script in bin/*; do
->   basename=$${script##*/}
->   if [[ -f $(USER_BIN)/$${basename} ]]; then
->     rm $(USER_BIN)/$${basename} && 
->       echo "-> Unstalling $(USER_BIN)/$${basename}"
->   fi
-> done
+	@echo "Uninstall git-helpers from $(USER_BIN)"
+	for script in bin/*; do
+		basename=$${script##*/}
+		if [[ -f $(USER_BIN)/$${basename} ]]; then
+			rm $(USER_BIN)/$${basename} && 
+			echo "-> Unstalling $(USER_BIN)/$${basename}"
+		fi
+	done
 
 # -----------------------------------------------------------------------------
 # Run tests
 # -----------------------------------------------------------------------------
 test:
-> bats tests/*.bats
+	bats tests/*.bats
+
+test-bash:
+	declare -a VERSIONS=( 4.2 4.3 4.4 5.0 5.1 )
+	function  install() {
+		apk add \
+		  bats \
+			coreutils \
+			git \
+			grep \
+			make; \
+	}; \
+	for version in $${VERSIONS[@]}; do \
+		docker run \
+			--rm \
+			--tty \
+			--volume $$(pwd):/git-helpers \
+			--workdir /git-helpers \
+			bash:$${version} \
+			bash -c "$$(declare -f install); install && make test"; \
+	done;
+
+# vim: shiftwidth=2 noexpandtab :

--- a/bin/git-stale-branches
+++ b/bin/git-stale-branches
@@ -21,7 +21,7 @@ shopt -u compat41 2>/dev/null || {
 # Globals
 # -----------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare -r VERSION=0.1.0
+declare -r VERSION=0.3.0
 declare -r AUTHOR="Urs Roesch <github@bun.ch>"
 declare -r LICENSE="GPLv2"
 declare -r THRESHOLD_DEFAULT='5 weeks ago'
@@ -94,7 +94,8 @@ function list_per_week() {
   printf "\n"
   while (( ${counter} > 0 )); do
     week_start=$(date -d "${counter} weeks ago" +%s)
-    read -a branches <<< $(filter_stale_branches ${week_start})
+    week_end=$(( week_start + 24 * 7 * 60 * 60 ))
+    read -a branches <<< $(filter_stale_branches ${week_start} ${week_end})
     if (( ${#branches[@]} > 0 )); then
       printf "%d weeks ago\n" ${counter}
       print_branch_info false "${branches[@]}"
@@ -108,9 +109,13 @@ function list_per_week() {
 
 function filter_stale_branches() {
   local week_start=${1}; shift;
-  local week_end=$(( week_start + 7 * 24 * 60 * 60 ))
+  local week_end=${1}; shift;
   git_branches | while read branch epoch; do
-    (( ${week_end} < ${epoch} || ${week_start} > ${epoch} )) && continue;
+    if (( ${week_end} == 0 )); then
+      (( ${week_start} < ${epoch} )) && continue;
+    else
+      (( ${week_end} < ${epoch} || ${week_start} > ${epoch} )) && continue;
+    fi
     printf " %b " "${epoch}" "${branch}"
   done
 }
@@ -131,7 +136,7 @@ function print_branch_info() {
 # -----------------------------------------------------------------------------
 
 function print_stale_branches() {
-  read -a branches <<< $(filter_stale_branches ${THRESHOLD})
+  read -a branches <<< $(filter_stale_branches ${THRESHOLD} 0)
   if (( ${#branches[@]} == 0 )); then
     printf "\nNo stale branch found\n"
     return 0;

--- a/tests/git-stale-branches.bats
+++ b/tests/git-stale-branches.bats
@@ -27,3 +27,26 @@ load helpers
     grep -w ${GIT_STALE_BRANCHES_VERSION}
 }
 
+@test "git stale-branches: Default operation" {
+  output=$(git-stale-branches) 
+  grep "2021-12-29 15:15:13  experimental/ocrpdf" <<< "${output}"
+  grep "2021-12-29 15:19:50  packaging/debian"    <<< "${output}"
+  grep "2022-01-26 22:03:29  main"                <<< "${output}"
+  grep "2022-01-26 22:25:07  feature/scan2pdf"    <<< "${output}"
+}
+
+@test "git stale-branches: Threshold 2 weeks ago" {
+  output=$(git-stale-branches --threshold '2 weeks ago')
+  grep "2021-12-29 15:15:13  experimental/ocrpdf" <<< "${output}"
+  grep "2021-12-29 15:19:50  packaging/debian"    <<< "${output}"
+  grep "2022-01-26 22:03:29  main"                <<< "${output}"
+  grep "2022-01-26 22:25:07  feature/scan2pdf"    <<< "${output}"
+}
+
+@test "git stale-branches: Per week" {
+  output=$(git-stale-branches --per-week)
+  grep "2021-12-29 15:15:13  experimental/ocrpdf" <<< "${output}"
+  grep "2021-12-29 15:19:50  packaging/debian"    <<< "${output}"
+  grep "2022-01-26 22:03:29  main"                <<< "${output}"
+  grep "2022-01-26 22:25:07  feature/scan2pdf"    <<< "${output}"
+}

--- a/tests/helpers/git
+++ b/tests/helpers/git
@@ -78,6 +78,14 @@ case "${@}" in
    * [new branch]      foobar -> foobar
   PUSH
   ;;
+'branch -r --sort=committerdate --format=%(refname:lstrip=3) %(committerdate:unix)')
+  cat <<"  BRANCH" | ltrim
+  experimental/ocrpdf 1640790913
+  packaging/debian 1640791190
+  main 1643234609
+  feature/scan2pdf 1643235907
+  BRANCH
+  ;;
 *) 
   echo ${NAME} ${@}
   ;;   

--- a/tests/includes.bash
+++ b/tests/includes.bash
@@ -8,10 +8,11 @@ export GIT_AUTOREBASE_VERSION="v0.7.1"
 export GIT_FPC_VERSION="v0.6.2"
 export GIT_OPUSH_VERSION="v0.6.1"
 export GIT_WALKTREE_VERSION="v0.1.3"
-export GIT_STALE_BRANCHES_VERSION="v0.1.0"
+export GIT_STALE_BRANCHES_VERSION="v0.3.0"
 export STRIP_TRAILING_WHITESPACE_VERSION="v0.6.0"
 export SHA256SUM_WHITESPACE_FILE="506dcd8e1fdd674bf75c87191145642a440cd4aa11a95fc37c4197f7a4e5118d"
 export SHA256SUM_WALKTREE="3393faccc9e1f6fd999c49e8efa1df5aed19900d3bbf1ca34b17b05ea34519ac"
+export TZ=UTC
 
 # -----------------------------------------------------------------------------
 # Functions


### PR DESCRIPTION
Summary:
  * Default operation mode stopped working with the
    last commit.
  * Added more test to ensure the output works for
    both modes now.