### PR TITLE
Convert hand-cranked-docker to container keyword

### DIFF
--- a/.github/workflows/bash-compatibility.yml
+++ b/.github/workflows/bash-compatibility.yml
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # Verify bash compatibility for git-helpers
 # Author: Urs Roesch https://github.com/uroesch
-# Version: 0.1.0
+# Version: 0.2.0
 # -----------------------------------------------------------------------------
 name: bash-compatibility
 
@@ -17,40 +17,39 @@ on:
 jobs:
   bash-compatibility:
     timeout-minutes: 15
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    container:
+      image: bash:${{ matrix.bash }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-        - ubuntu-latest
         bash:
-        - '4.2'
-        - '4.3'
-        - '4.4'
-        - '5.0'
-        - '5.1'
+          - '4.2'
+          - '4.3'
+          - '4.4'
+          - '5.0'
+          - '5.1'
 
     steps:
+    - name: Install dependencies
+      shell: bash
+      run: |
+        apk add \
+          bats \
+          coreutils \
+          git \
+          grep \
+          make
+
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
-    - name: Loop test
+    - name: Configure git
       shell: bash
-      run: |
-        function setup() {
-          apk add \
-            bats \
-            coreutils \
-            git \
-            grep \
-            make;
-            git config --global --add safe.directory /git-helpers;
-        }
-        docker run \
-          --tty \
-          --volume $(pwd):/git-helpers \
-          --workdir /git-helpers \
-          bash:${{ matrix.bash }} \
-          bash -c "$(declare -f setup); setup && make test && echo \${BASH_VERSION}"
+      run: git config --global --add safe.directory '*';
+
+    - name: Test bash compatibility 
+      shell: bash
+      run: make test 


### PR DESCRIPTION
- Use the container keyword instead of hand cranking the docker initialization.
- More readable than whacky bash functions :)