### PR TITLE
Add Debian 12 to the OS compatibilty checks

### DIFF
--- a/.github/workflows/os-compatibilty.yml
+++ b/.github/workflows/os-compatibilty.yml
@@ -23,9 +23,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - { name: debian,      release: 9 }
           - { name: debian,      release: 10 }
           - { name: debian,      release: 11 }
+          - { name: debian,      release: 12 }
           - { name: ubuntu,      release: 16.04 }
           - { name: ubuntu,      release: 18.04 }
           - { name: ubuntu,      release: 20.04 }
@@ -80,7 +80,7 @@ jobs:
       shell: bash
       run: |
         yum -y install epel-release
-        yum -y install bats git make 
+        yum -y install bats git make
 
     - name: Checkout repository
       uses: actions/checkout@v3


### PR DESCRIPTION
- Remove Debian 9 as the container no longer works.
- Add the newly minted Debian 12 to OS compatibilty.